### PR TITLE
Switch resource name instead of command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,10 +54,11 @@ define runonce (
     $semaphore = "/tmp/puppet-semaphore-${title}"
   }
 
-  exec { $command:
-    unless      => "ls ${semaphore}",
-    path        => '/bin:/usr/bin:/sbin:/usr/sbin',
-    require     => File[$persistent_dir],
+  exec { $name:
+    command => "$command",
+    unless  => "ls ${semaphore}",
+    path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+    require => File[$persistent_dir],
   } ~>
 
   file { $semaphore:


### PR DESCRIPTION
Using command as the resource name can cause conflicts with other exec's defined in other modules - in my case it was apt-get update which is used in the apt module. Using the runonce name as the resource name means that you can have duplicate commands across the codebase.